### PR TITLE
feat: bump minor version to 75

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+## 2.2.0 (unreleased)
+
+* Set default minor version to 75
+  * You can override the minor version by setting `Quickbooks.minorversion = XX` (where `XX` in the minor version like `47`)
+
 ## 2.1.0 (2025-01-22)
 
 ### Breaking changes

--- a/lib/quickbooks-ruby.rb
+++ b/lib/quickbooks-ruby.rb
@@ -191,7 +191,7 @@ require 'quickbooks/service/refund_receipt_change'
 module Quickbooks
   @@sandbox_mode = false
   @@logger = nil
-  @@minorversion = 47
+  @@minorversion = 75
   @@http_adapter = :net_http
 
   class << self


### PR DESCRIPTION
Per QB, all minor version from 1-74 will be ignored on 8/1/25. This will update the minor version to a default of 75 to follow that requirement.

closes #4